### PR TITLE
Add difftastic-dired-diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The following commands are meant to help to interact with `difftastic`. Commands
 - `difftastic-magit-show` - show the result of `git show ARG` with `difftastic`. It tries to guess `ARG`, and ask for it when can't. When called with prefix argument it will ask for `ARG`.
 - `difftastic-files` - show the result of `difft FILE-A FILE-B`. When called with prefix argument it will ask for language to use, instead of relaying on `difftastic`'s detection mechanism.
 - `difftastic-buffers` - show the result of `difft BUFFER-A BUFFER-B`. Language is guessed based on buffers modes. When called with prefix argument it will ask for language to use.
-- `difftastic-dired` - same as `dired-diff`, but with `difftastic-files` instead of the built-in `diff`.
+- `difftastic-dired-diff` - same as `dired-diff`, but with `difftastic-files` instead of the built-in `diff`.
 - `difftastic-rerun` (<kbd>g</kbd>) - rerun difftastic for the current buffer. It runs difftastic again in the current buffer, but respects the window configuration.
 It uses `difftastic-rerun-requested-window-width-function` which, by default, returns current window width (instead of `difftastic-requested-window-width-function`). It will also reuse current buffer and will not call `difftastic-display-buffer-function`. When called with prefix argument it will ask for language to use.
 - `difftastic-next-chunk` (<kbd>n</kbd>), `difftastic-next-file` (<kbd>N</kbd>) - move point to a next logical chunk or a next file respectively.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following commands are meant to help to interact with `difftastic`. Commands
 - `difftastic-magit-show` - show the result of `git show ARG` with `difftastic`. It tries to guess `ARG`, and ask for it when can't. When called with prefix argument it will ask for `ARG`.
 - `difftastic-files` - show the result of `difft FILE-A FILE-B`. When called with prefix argument it will ask for language to use, instead of relaying on `difftastic`'s detection mechanism.
 - `difftastic-buffers` - show the result of `difft BUFFER-A BUFFER-B`. Language is guessed based on buffers modes. When called with prefix argument it will ask for language to use.
+- `difftastic-dired` - same as `dired-diff`, but with `difftastic-files` instead of the built-in `diff`.
 - `difftastic-rerun` (<kbd>g</kbd>) - rerun difftastic for the current buffer. It runs difftastic again in the current buffer, but respects the window configuration.
 It uses `difftastic-rerun-requested-window-width-function` which, by default, returns current window width (instead of `difftastic-requested-window-width-function`). It will also reuse current buffer and will not call `difftastic-display-buffer-function`. When called with prefix argument it will ask for language to use.
 - `difftastic-next-chunk` (<kbd>n</kbd>), `difftastic-next-file` (<kbd>N</kbd>) - move point to a next logical chunk or a next file respectively.

--- a/difftastic.el
+++ b/difftastic.el
@@ -1045,15 +1045,23 @@ running difftastic."
    lang-override))
 
 ;;;###autoload
-(defun difftastic-dired ()
+(defun difftastic-dired-diff (file &optional lang-override)
   "Compare file at point with FILE using difftastic.
 
-The behavior is the same as `dired-diff'."
-  (interactive)
+The behavior is the same as `dired-diff', except for the prefix argument, which
+makes the function prompt for LANG-OVERRIDE.  See 'difft --list-languages' for
+language list."
+  (interactive
+   (list 'interactive
+         (when current-prefix-arg
+           (completing-read "Language: " (difftastic--languages) nil t))))
   (cl-letf (((symbol-function 'diff)
              (lambda (current file _switches)
-               (difftastic-files current file))))
-    (call-interactively #'dired-diff)))
+               (difftastic-files current file lang-override)))
+            (current-prefix-arg nil))
+    (if (eq file 'interactive)
+        (call-interactively #'dired-diff))
+    (funcall #'dired-diff file)))
 
 (defun difftastic--rerun-file-buf (prefix file-buf rerun-alist)
   "Create a new temporary file for the FILE-BUF with PREFIX if needed.

--- a/difftastic.el
+++ b/difftastic.el
@@ -84,6 +84,9 @@
 ;;   Language is guessed based on buffers modes.  When called with prefix
 ;;   argument it will ask for language to use.
 ;;
+;; - `difftastic-dired' - same as `dired-diff', but with `difftastic-files'
+;;   instead of the built-in `diff'.
+;;
 ;; - `difftastic-rerun' ('g') - rerun difftastic for the current buffer.  It
 ;;   runs difftastic again in the current buffer, but respects the window
 ;;   configuration.  It uses `difftastic-rerun-requested-window-width-function'
@@ -105,6 +108,7 @@
 
 (require 'ansi-color)
 (require 'cl-lib)
+(require 'dired)
 (require 'ediff)
 (require 'font-lock)
 (require 'magit)
@@ -1039,6 +1043,17 @@ running difftastic."
    (cons file-A nil)
    (cons file-B nil)
    lang-override))
+
+;;;###autoload
+(defun difftastic-dired ()
+  "Compare file at point with FILE using difftastic.
+
+The behavior is the same as `dired-diff'."
+  (interactive)
+  (cl-letf (((symbol-function 'diff)
+             (lambda (current file _switches)
+               (difftastic-files current file))))
+    (call-interactively #'dired-diff)))
 
 (defun difftastic--rerun-file-buf (prefix file-buf rerun-alist)
   "Create a new temporary file for the FILE-BUF with PREFIX if needed.

--- a/difftastic.el
+++ b/difftastic.el
@@ -84,8 +84,8 @@
 ;;   Language is guessed based on buffers modes.  When called with prefix
 ;;   argument it will ask for language to use.
 ;;
-;; - `difftastic-dired' - same as `dired-diff', but with `difftastic-files'
-;;   instead of the built-in `diff'.
+;; - `difftastic-dired-diff' - same as `dired-diff', but with
+;;   `difftastic-files' instead of the built-in `diff'.
 ;;
 ;; - `difftastic-rerun' ('g') - rerun difftastic for the current buffer.  It
 ;;   runs difftastic again in the current buffer, but respects the window

--- a/difftastic.el
+++ b/difftastic.el
@@ -1049,8 +1049,8 @@ running difftastic."
   "Compare file at point with FILE using difftastic.
 
 The behavior is the same as `dired-diff', except for the prefix argument, which
-makes the function prompt for LANG-OVERRIDE.  See 'difft --list-languages' for
-language list."
+makes the function prompt for LANG-OVERRIDE.  See \\='difft
+--list-languages\\=' for language list."
   (interactive
    (list 'interactive
          (when current-prefix-arg


### PR DESCRIPTION
This adds a version of `dired-diff` that makes use of this package.

There's a lot going on in the interactive block of the original function, so I thought `cl-letf` would make more sense than just copying the function.