### PR TITLE
Fix usage with Tramp

### DIFF
--- a/difftastic.el
+++ b/difftastic.el
@@ -1790,6 +1790,7 @@ perform cleanup.  It returns a process created by `make-process'."
    :command command
    :noquery t
    :filter #'difftastic--run-command-filter
+   :file-handler t
    :sentinel
    (lambda (process _event)
      (difftastic--run-command-sentinel process action command))))


### PR DESCRIPTION
Pass `:file-handler t` to `make-process` so that the command will be run on the remote host.