### PR TITLE
Use `magit-split-range` to parse string ranges.

### DIFF
--- a/difftastic.el
+++ b/difftastic.el
@@ -1418,17 +1418,13 @@ and run `difftastic-diff-visit-file-hook'."
                                              difftastic--metadata))
                (rev (if-let* ((rev-or-range (alist-get 'rev-or-range
                                                        difftastic--metadata))
-                              (range (cond
-                                      ((and
-                                        (stringp rev-or-range)
-                                        (string-match-p (rx "..") rev-or-range))
-                                       (string-split rev-or-range (rx "..")))
-                                      ((stringp rev-or-range)
-                                       (list (concat rev-or-range "^")
-                                             rev-or-range)))))
+                              (range (when (stringp rev-or-range)
+                                       (or (magit-split-range rev-or-range)
+                                           (cons (concat rev-or-range "^")
+                                                 rev-or-range)))))
                         (if (eq side 'left)
                             (car range)
-                          (cadr range))
+                          (cdr range))
                       rev-or-range))
                (buf (if (or force-worktree
                             (and (not (stringp rev))


### PR DESCRIPTION
This adds support for `...`, which is generated by magit/forge when diffing a PR. E.g., `origin/master...refs/pullreqs/123`